### PR TITLE
基本的过滤功能完成。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.pro.user
+*.autosave

--- a/examples/tableview/grades.qrc
+++ b/examples/tableview/grades.qrc
@@ -1,6 +1,5 @@
 <RCC>
     <qresource prefix="/">
         <file>grades.txt</file>
-        <file>msg_name_table.csv</file>
     </qresource>
 </RCC>

--- a/examples/tableview/grades.qrc
+++ b/examples/tableview/grades.qrc
@@ -1,5 +1,6 @@
 <RCC>
-    <qresource prefix="/" >
+    <qresource prefix="/">
         <file>grades.txt</file>
+        <file>msg_name_table.csv</file>
     </qresource>
 </RCC>

--- a/examples/tableview/main.cpp
+++ b/examples/tableview/main.cpp
@@ -1,72 +1,14 @@
-
-#include <QApplication>
-#include <QMainWindow>
-#include <QStandardItemModel>
-#include <QFile>
-#include <QAction>
-#include <QVBoxLayout>
-#include <QShortcut>
-
+#include "widgets/window.h"
 #include "widgets/ntableview.h"
 #include "widgets/nfindbar.h"
+#include "widgets/nfilterbar.h"
+#include "widgets/nsortfilterproxymodel.h"
 
 int main(int argc, char* argv[])
 {
     Q_INIT_RESOURCE(grades);
-
     QApplication app( argc, argv );
-    QMainWindow* mainwin = new QMainWindow();
-
-    mainwin->setCentralWidget(new QWidget());
-    QVBoxLayout* layout = new QVBoxLayout();
-    mainwin->centralWidget()->setLayout(layout);
-
-
-    QStandardItemModel *model=new QStandardItemModel();
-
-    QFile file(":/grades.txt");
-    if (file.open(QFile::ReadOnly)) {
-        QString line = file.readLine(200);
-        QStringList list = line.simplified().split(',');
-        model->setHorizontalHeaderLabels(list);
-
-        int row = 0;
-        QStandardItem *newItem = 0;
-        while (file.canReadLine()) {
-            line = file.readLine(200);
-            if (!line.startsWith('#') && line.contains(',')) {
-                list = line.simplified().split(',');
-                for (int col = 0; col < list.length(); ++col){
-                    newItem = new QStandardItem(list.at(col));
-                    model->setItem(row, col, newItem);
-                }
-                ++row;
-            }
-        }
-    }
-    file.close();
-
-    NTableView *tableView = new NTableView(model);
-    layout->addWidget(tableView);
-
-    NFindBar* findbar = new NFindBar(tableView);
-
-    QStringList header_list;
-    {
-        for (int i=1; i < model->columnCount(); ++i)
-        {
-            header_list.append(model->horizontalHeaderItem(i)->text());
-        }
-    }
-    findbar->hide();
-    layout->addWidget(findbar);
-
-    QAction* find_action = new QAction("Find", tableView);
-    find_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F));
-    QObject::connect(find_action, SIGNAL(triggered()), findbar, SLOT(show()));
-    tableView->addAction(find_action);
-
-    mainwin->show();
+    Window window;
     return app.exec();
 }
 

--- a/examples/tableview/tableview.pro
+++ b/examples/tableview/tableview.pro
@@ -3,10 +3,16 @@ TARGET       = tableview
 TEMPLATE     = app
 SOURCES     += main.cpp \
                ../../fire/src/widgets/tableview/ntableview.cpp \
-               ../../fire/src/widgets/tableview/nfindbar.cpp
+               ../../fire/src/widgets/tableview/nfindbar.cpp \
+               ../../fire/src/widgets/tableview/nfilterbar.cpp \
+               ../../fire/src/widgets/tableview/nsortfilterproxymodel.cpp \
+               ../../fire/src/widgets/tableview/window.cpp
 
 HEADERS     += ../../fire/include/widgets/ntableview.h \
-               ../../fire/include/widgets/nfindbar.h
+               ../../fire/include/widgets/nfindbar.h \
+               ../../fire/include/widgets/nfilterbar.h \
+               ../../fire/include/widgets/nsortfilterproxymodel.h \
+               ../../fire/include/widgets/window.h
 
 
 INCLUDEPATH += ../../fire/include

--- a/fire/include/widgets/nfilterbar.h
+++ b/fire/include/widgets/nfilterbar.h
@@ -1,5 +1,5 @@
-#ifndef NFINDBAR_H
-#define NFINDBAR_H
+#ifndef NFILTERBAR_H
+#define NFILTERBAR_H
 
 #include <QWidget>
 #include <QLineEdit>
@@ -10,16 +10,16 @@
 #include <QRegExp>
 
 
+//Q_DECLARE_METATYPE(QRegExp::PatternSyntax)
 
-class NFindBar : public QWidget
+class NFilterBar : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity)
     Q_PROPERTY(QRegExp::PatternSyntax patternSyntax READ patternSyntax WRITE setPatternSyntax)
 
 signals:
-    void prevBtnClicked();
-    void nextBtnClicked();
+    void filterBtnClicked();
     void filterChanged();
 
 public:
@@ -30,7 +30,7 @@ public:
         UseRegularExp = 4
     };
 
-    explicit NFindBar(QWidget *parent = nullptr);
+    explicit NFilterBar(QWidget *parent = nullptr);
 
 
     Qt::CaseSensitivity caseSensitivity() const;
@@ -39,16 +39,20 @@ public:
 
     QRegExp::PatternSyntax patternSyntax() const;
     void setPatternSyntax(QRegExp::PatternSyntax s);
-protected:
 
-    QLineEdit   find_editor;
-    QPushButton find_prev_item;
-    QPushButton find_next_item;
+    QString get_filter_editor_text() const { return filter_editor.text();}
+    void append_column_name_to_filter_text(QString head);
+
+    QLineEdit const &get_filter_editor();
+
+private:
+
+    QLineEdit   filter_editor;
+    QPushButton filter_button;
     QPushButton close_button;
 
     QAction      *case_sensitivity_action_;
     QActionGroup *pattern_group_;
 
 };
-
-#endif // NFINDBAR_H
+#endif // NFILTERBAR_H

--- a/fire/include/widgets/nfilterbar.h
+++ b/fire/include/widgets/nfilterbar.h
@@ -9,9 +9,6 @@
 #include <QActionGroup>
 #include <QRegExp>
 
-
-//Q_DECLARE_METATYPE(QRegExp::PatternSyntax)
-
 class NFilterBar : public QWidget
 {
     Q_OBJECT
@@ -21,6 +18,9 @@ class NFilterBar : public QWidget
 signals:
     void filterBtnClicked();
     void filterChanged();
+
+public slots:
+    void show_hide();
 
 public:
     enum SearchSpec

--- a/fire/include/widgets/nfindbar.h
+++ b/fire/include/widgets/nfindbar.h
@@ -22,6 +22,9 @@ signals:
     void nextBtnClicked();
     void filterChanged();
 
+public slots:
+    void show_hide();
+
 public:
     enum SearchSpec
     {

--- a/fire/include/widgets/nsortfilterproxymodel.h
+++ b/fire/include/widgets/nsortfilterproxymodel.h
@@ -1,0 +1,40 @@
+#ifndef NSORTFILTERPROXYMODEL_H
+#define NSORTFILTERPROXYMODEL_H
+#include <QtWidgets>
+#include <QSortFilterProxyModel>
+#include <QRegExp>
+#include <QVector>
+#include <QMap>
+
+using namespace std;
+class NSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    NSortFilterProxyModel(QObject *parent = 0);
+    // append : append new column with relative regexp vector
+    void append(int column, QVector<QRegExp> reg_vec);
+    // clear : clear reg_dic
+    void clear();
+    // set_switcher : change the filter type
+    void set_switcher(bool flag);
+    // get_switcher : return the value of switch
+    bool get_switcher();
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+//  if need to sort override the function below
+//    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+
+private:
+    QMap<int, QVector<QRegExp>> reg_dic;
+    // switcher is a switcher for start a complex filter type
+    bool switcher = FALSE;
+
+};
+//! [0]
+
+
+#endif // NSORTFILTERPROXYMODEL_H

--- a/fire/include/widgets/ntableview.h
+++ b/fire/include/widgets/ntableview.h
@@ -5,32 +5,35 @@
 
 //! [Widget definition]
 class NTableView : public QTableView {
-     Q_OBJECT
+    Q_OBJECT
 
 public:
-      NTableView(QAbstractItemModel * model);
-      ~NTableView();
+    NTableView(QAbstractItemModel * model, QWidget* parent=Q_NULLPTR);
+    ~NTableView();
+
+signals:
+    void get_head(int head_index);
 
 public slots:
-      void freezeSection(int logicalIndex);
-      void cancelFreeze();
+    void freezeSection(int logicalIndex);
+    void cancelFreeze();
 
 protected:
-      void resizeEvent(QResizeEvent *event) override;
-      QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
-      void scrollTo (const QModelIndex & index, ScrollHint hint = EnsureVisible) override;
+    void resizeEvent(QResizeEvent *event) override;
+    QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
+    void scrollTo (const QModelIndex & index, ScrollHint hint = EnsureVisible) override;
 
 private:
-      void init();
-      void updateFrozenTableGeometry();
-      //
-      QTableView *frozenTableView;
-      int         currentSection_;
+    void init();
+    void updateFrozenTableGeometry();
+    //
+    QTableView *frozenTableView;
+    int         currentSection_;
 
 private slots:
-      void updateSectionWidth(int logicalIndex, int oldSize, int newSize);
-      void updateSectionHeight(int logicalIndex, int oldSize, int newSize);
-      void onHHeaderCtxMenuRequested(QPoint pos);
+    void updateSectionWidth(int logicalIndex, int oldSize, int newSize);
+    void updateSectionHeight(int logicalIndex, int oldSize, int newSize);
+    void onHHeaderCtxMenuRequested(QPoint pos);
 
 };
 //! [Widget definition]

--- a/fire/include/widgets/window.h
+++ b/fire/include/widgets/window.h
@@ -1,0 +1,53 @@
+#ifndef WINDOW_H
+#define WINDOW_H
+#include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QAbstractItemModel;
+class QStandardItemModel;
+class QCheckBox;
+class QComboBox;
+class QDateEdit;
+class QMainWindow;
+class QLabel;
+class QLineEdit;
+class QStringList;
+class QVBoxLayout;
+
+QT_END_NAMESPACE
+class NFilterBar;
+class NFindBar;
+class NSortFilterProxyModel;
+class NTableView;
+
+//! [0]
+class Window : public QWidget
+{
+    Q_OBJECT
+
+public:
+    Window();
+
+
+private slots:
+    void filter();
+    void prev();
+    void next();
+    void rec_head(int head_index);
+
+private:
+    NFindBar *nfindBar;
+    NFilterBar *nfilterBar;
+    NTableView *ntableView;
+    NSortFilterProxyModel *nsortfilterproxyModel;
+
+    QMainWindow *qmainWindow;
+    QVBoxLayout *qvboxLayout;
+    QStandardItemModel *sourceModel;
+    QStringList header_list;
+    void global_filter();
+};
+//! [0]
+
+
+#endif // WINDOW_H

--- a/fire/src/widgets/tableview/nfilterbar.cpp
+++ b/fire/src/widgets/tableview/nfilterbar.cpp
@@ -68,6 +68,10 @@ NFilterBar::NFilterBar(QWidget *parent)
 // append formatted column name to the search text
 void NFilterBar::append_column_name_to_filter_text(QString head)
 {
+    if(isHidden())
+    {
+        show();
+    }
     QString current_text = filter_editor.text();
     if (current_text.trimmed().isEmpty())
     {
@@ -80,6 +84,19 @@ void NFilterBar::append_column_name_to_filter_text(QString head)
         current_text.append(" | \"" + head + "\" = {\"\"}");
     }
     filter_editor.setText(current_text);
+}
+
+//
+void NFilterBar::show_hide()
+{
+    if(isHidden())
+    {
+        show();
+    }
+    else
+    {
+        hide();
+    }
 }
 
 QLineEdit const & NFilterBar::get_filter_editor()

--- a/fire/src/widgets/tableview/nfindbar.cpp
+++ b/fire/src/widgets/tableview/nfindbar.cpp
@@ -38,8 +38,6 @@ NFindBar::NFindBar(QWidget *parent)
     close_button.setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
     connect(&close_button, &QPushButton::clicked, this, &QWidget::hide);
 
-
-
     QMenu *menu = new QMenu(this);
     case_sensitivity_action_ = menu->addAction(tr("Case Sensitive"));
     case_sensitivity_action_->setCheckable(true);
@@ -71,6 +69,18 @@ NFindBar::NFindBar(QWidget *parent)
     QWidgetAction *optionsAction = new QWidgetAction(&find_editor);
     optionsAction->setDefaultWidget(optionsButton);
     find_editor.addAction(optionsAction, QLineEdit::LeadingPosition);
+}
+
+void NFindBar::show_hide()
+{
+    if(isHidden())
+    {
+        show();
+    }
+    else
+    {
+        hide();
+    }
 }
 
 Qt::CaseSensitivity NFindBar::caseSensitivity() const

--- a/fire/src/widgets/tableview/nsortfilterproxymodel.cpp
+++ b/fire/src/widgets/tableview/nsortfilterproxymodel.cpp
@@ -1,6 +1,5 @@
 #include "widgets/nsortfilterproxymodel.h"
 
-//! [0]
 NSortFilterProxyModel::NSortFilterProxyModel(QObject *parent)
     : QSortFilterProxyModel(parent)
 {
@@ -29,10 +28,7 @@ bool NSortFilterProxyModel::get_switcher()
 {
     return switcher;
 }
-//! [0]
 
-//! [1]
-//!
 bool NSortFilterProxyModel::filterAcceptsRow(int sourceRow,
         const QModelIndex &sourceParent) const
 {
@@ -69,32 +65,5 @@ bool NSortFilterProxyModel::filterAcceptsRow(int sourceRow,
         return ret;
     }
 }
-//! [1]
 
-//! [2] //! [3]
-//bool NSortFilterProxyModel::lessThan(const QModelIndex &left,
-//                                      const QModelIndex &right) const
-//{
-//    QVariant leftData = sourceModel()->data(left);
-//    QVariant rightData = sourceModel()->data(right);
-////! [2]
-
-////! [4]
-//    if (leftData.type() == QVariant::DateTime) {
-//        return leftData.toDateTime() < rightData.toDateTime();
-//    } else {
-//        static QRegExp emailPattern("[\\w\\.]*@[\\w\\.]*)");
-
-//        QString leftString = leftData.toString();
-//        if(left.column() == 1 && emailPattern.indexIn(leftString) != -1)
-//            leftString = emailPattern.cap(1);
-
-//        QString rightString = rightData.toString();
-//        if(right.column() == 1 && emailPattern.indexIn(rightString) != -1)
-//            rightString = emailPattern.cap(1);
-
-//        return QString::localeAwareCompare(leftString, rightString) < 0;
-//    }
-//}
-//! [3] //! [4]
 

--- a/fire/src/widgets/tableview/nsortfilterproxymodel.cpp
+++ b/fire/src/widgets/tableview/nsortfilterproxymodel.cpp
@@ -1,0 +1,100 @@
+#include "widgets/nsortfilterproxymodel.h"
+
+//! [0]
+NSortFilterProxyModel::NSortFilterProxyModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+}
+
+// Insert a new instance into the reg_dic
+void NSortFilterProxyModel::append(int column, QVector<QRegExp> reg_vec)
+{
+    reg_dic.insert(column, reg_vec);
+}
+
+// Clear the reg_dic
+void NSortFilterProxyModel::clear()
+{
+    reg_dic.clear();
+}
+
+// Set the switcher to a specific mode
+void NSortFilterProxyModel::set_switcher(bool flag)
+{
+    switcher = flag;
+}
+
+// Get current switcher
+bool NSortFilterProxyModel::get_switcher()
+{
+    return switcher;
+}
+//! [0]
+
+//! [1]
+//!
+bool NSortFilterProxyModel::filterAcceptsRow(int sourceRow,
+        const QModelIndex &sourceParent) const
+{
+    bool ret = FALSE;
+    // swticher TRUE : go to complex filter mode
+    if(switcher)
+    {
+        // In complex filter mode, ret is initialed TRUE because we will use "&="
+        ret = TRUE;
+        // Logic process : We use "|=" for the same column and "&=" for different columns
+        for(QMap<int, QVector<QRegExp>>::const_iterator map_itr = reg_dic.begin(); map_itr != reg_dic.end(); ++map_itr)
+        {
+            bool temp_ret = FALSE;
+            int col = map_itr.key();
+            for(QVector<QRegExp>::const_iterator reg_itr = map_itr.value().begin(); reg_itr != map_itr.value().end(); ++reg_itr)
+            {
+                QModelIndex temp_index = sourceModel()->index(sourceRow, col, sourceParent);
+                temp_ret |= sourceModel()->data(temp_index).toString().contains(*reg_itr);
+            }
+            ret &= temp_ret;
+        }
+        return ret;
+    }
+    // switcher FALSE : go to global filter mode
+    else
+    {
+        // Logic procee : We use "|=" to match each element in tableview
+        int col_count = sourceModel()->columnCount();
+        for(int i = 0; i < col_count; ++i)
+        {
+            QModelIndex temp_index = sourceModel()->index(sourceRow, i, sourceParent);
+            ret |= sourceModel()->data(temp_index).toString().contains(filterRegExp());
+        }
+        return ret;
+    }
+}
+//! [1]
+
+//! [2] //! [3]
+//bool NSortFilterProxyModel::lessThan(const QModelIndex &left,
+//                                      const QModelIndex &right) const
+//{
+//    QVariant leftData = sourceModel()->data(left);
+//    QVariant rightData = sourceModel()->data(right);
+////! [2]
+
+////! [4]
+//    if (leftData.type() == QVariant::DateTime) {
+//        return leftData.toDateTime() < rightData.toDateTime();
+//    } else {
+//        static QRegExp emailPattern("[\\w\\.]*@[\\w\\.]*)");
+
+//        QString leftString = leftData.toString();
+//        if(left.column() == 1 && emailPattern.indexIn(leftString) != -1)
+//            leftString = emailPattern.cap(1);
+
+//        QString rightString = rightData.toString();
+//        if(right.column() == 1 && emailPattern.indexIn(rightString) != -1)
+//            rightString = emailPattern.cap(1);
+
+//        return QString::localeAwareCompare(leftString, rightString) < 0;
+//    }
+//}
+//! [3] //! [4]
+

--- a/fire/src/widgets/tableview/ntableview.cpp
+++ b/fire/src/widgets/tableview/ntableview.cpp
@@ -3,7 +3,6 @@
 #include <QScrollBar>
 #include <QHeaderView>
 
-
 //! [constructor]
 NTableView::NTableView(QAbstractItemModel * model, QWidget* parent)
     : QTableView (parent)

--- a/fire/src/widgets/tableview/ntableview.cpp
+++ b/fire/src/widgets/tableview/ntableview.cpp
@@ -1,13 +1,13 @@
 #include "widgets/ntableview.h"
-
 #include <QMenu>
 #include <QScrollBar>
 #include <QHeaderView>
 
 
 //! [constructor]
-NTableView::NTableView(QAbstractItemModel * model)
-    : currentSection_(0)
+NTableView::NTableView(QAbstractItemModel * model, QWidget* parent)
+    : QTableView (parent)
+    , currentSection_(0)
 {
 
     horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -89,6 +89,11 @@ void NTableView::onHHeaderCtxMenuRequested(QPoint pos)
             setColumnHidden(column, false);
         }
     });
+
+    menu->addSeparator();
+
+    QAction* filterSection = menu->addAction("Filter Append");
+    connect(filterSection, &QAction::triggered, this, [this]{ emit get_head(currentSection_);});
 
     menu->exec(globalPos);
 }

--- a/fire/src/widgets/tableview/window.cpp
+++ b/fire/src/widgets/tableview/window.cpp
@@ -11,7 +11,7 @@
 QStandardItemModel* parseCSV(QStringList &header_list)
 {
     QStandardItemModel* csvModel = new QStandardItemModel();
-    QFile file(":/msg_name_table.csv");
+    QFile file("D:/Huang/msg_name_table.csv");
 
     if ( !file.open(QFile::ReadOnly | QFile::Text) ) {
         qDebug() << "File not exists";
@@ -99,7 +99,6 @@ void Window::filter()
     QRegExpValidator v2(rx2);
     int pos = 0;
     QString text = nfilterBar->get_filter_editor_text();
-//    qDebug() <<v2.validate(text, pos);
     // If a valid text which can pass the regexp validator is inputted, set the switcher TRUE and start complex filter mode
     //     else go to global filter
     if(v2.validate(text, pos) == 2 && (nfilterBar->patternSyntax() == 2 || nfilterBar->patternSyntax() == 3))

--- a/fire/src/widgets/tableview/window.cpp
+++ b/fire/src/widgets/tableview/window.cpp
@@ -1,0 +1,207 @@
+#include <widgets/nfilterbar.h>
+#include <widgets/nfindbar.h>
+#include <widgets/nsortfilterproxymodel.h>
+#include <widgets/ntableview.h>
+#include <widgets/window.h>
+#include <QtWidgets>
+#include <QVector>
+#include <QMainWindow>
+
+// the parameter is used to set header_list
+QStandardItemModel* parseCSV(QStringList &header_list)
+{
+    QStandardItemModel* csvModel = new QStandardItemModel();
+    QFile file(":/msg_name_table.csv");
+
+    if ( !file.open(QFile::ReadOnly | QFile::Text) ) {
+        qDebug() << "File not exists";
+    } else {
+        // Create a thread to retrieve data from a file
+        QString line = file.readLine();
+        QStringList list = line.simplified().split(',');
+        csvModel->setHorizontalHeaderLabels(list);
+        header_list = list;
+        QTextStream in(&file);
+        //Reads the data up to the end of file
+        while (!in.atEnd())
+        {
+            QString line = in.readLine();
+            // Adding to the model in line with the elements
+            QList<QStandardItem *> standardItemsList;
+            // consider that the line separated by semicolons into columns
+            for (QString item : line.split(",")) {
+                standardItemsList.append(new QStandardItem(item));
+            }
+            csvModel->insertRow(csvModel->rowCount(), standardItemsList);
+        }
+        file.close();
+    }
+    return csvModel;
+}
+
+Window::Window()
+{
+    // Create main window
+    qmainWindow = new QMainWindow();
+    qmainWindow->setCentralWidget(new QWidget());
+    qmainWindow->resize(860, 640);
+
+    // Load source model, load proxy model with source model.Then set the proxy model as source model in tableview
+    sourceModel = new QStandardItemModel();
+    sourceModel = parseCSV(header_list);
+    nsortfilterproxyModel = new NSortFilterProxyModel();
+    nsortfilterproxyModel->setSourceModel(sourceModel);
+    ntableView = new NTableView(nsortfilterproxyModel);
+
+    // Add widgets and set specific attributes
+    qvboxLayout = new QVBoxLayout();
+    qmainWindow->centralWidget()->setLayout(qvboxLayout);
+    qvboxLayout->addWidget(ntableView);
+    nfilterBar = new NFilterBar(ntableView);
+    qvboxLayout->addWidget(nfilterBar);
+    nfilterBar->hide();
+    nfindBar = new NFindBar(ntableView);
+    qvboxLayout->addWidget(nfindBar);
+    nfindBar->hide();
+
+    // Add connections
+    QObject::connect(nfilterBar, SIGNAL(filterBtnClicked()), this, SLOT(filter()));
+    QObject::connect(nfindBar, SIGNAL(prevBtnClicked()), this, SLOT(prev()));
+    QObject::connect(nfindBar, SIGNAL(nextBtnClicked()), this, SLOT(next()));
+    QObject::connect(ntableView, SIGNAL(get_head(int)), this, SLOT(rec_head(int)));
+
+    QObject::connect(&nfilterBar->get_filter_editor(), SIGNAL(returnPressed()), nfilterBar, SIGNAL(filterBtnClicked()), Qt::UniqueConnection);
+    // Bind action with slots and connect
+    QAction* find_action = new QAction("Find", ntableView);
+    find_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F));
+    QObject::connect(find_action, SIGNAL(triggered()), nfindBar, SLOT(show()));
+    ntableView->addAction(find_action);
+
+    QAction* filter_action = new QAction("Filter", ntableView);
+    filter_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_I));
+    QObject::connect(filter_action, SIGNAL(triggered()), nfilterBar, SLOT(show()));
+    ntableView->addAction(filter_action);
+
+    // Show main window
+    qmainWindow->show();
+}
+
+// Receive head index from ntableview, parse it into the specific column name and append
+void Window::rec_head(int head_index)
+{
+    nfilterBar->append_column_name_to_filter_text(header_list[head_index]);
+}
+
+// Filter function can filter specific rows the user want with fixed string or regexps
+void Window::filter()
+{
+    QRegExp rx2("\\s*\"[^,\"]*\"\\s*=\\s*\\{\\s*\(\"[^,\"]*\"\)\\s*\(,\\s*\"[^,\"]*\"\\s*\)*\\s*\\}\\s*\(\\|\(\\s*\"[^,\"]*\"\\s*=\\s*\\{\\s*\(\"[^,\"]*\"\)\\s*\(,\\s*\"[^,\"]*\"\\s*\)*\\s*\\}\\s*\)\)*");
+    QRegExpValidator v2(rx2);
+    int pos = 0;
+    QString text = nfilterBar->get_filter_editor_text();
+//    qDebug() <<v2.validate(text, pos);
+    // If a valid text which can pass the regexp validator is inputted, set the switcher TRUE and start complex filter mode
+    //     else go to global filter
+    if(v2.validate(text, pos) == 2 && (nfilterBar->patternSyntax() == 2 || nfilterBar->patternSyntax() == 3))
+    {
+        nsortfilterproxyModel->set_switcher(TRUE);
+        nsortfilterproxyModel->clear();
+        QStringList list = nfilterBar->get_filter_editor_text().split("|");
+        for(QString per_string:list)
+        {
+            if(!v2.validate(per_string, pos))
+            {
+                global_filter();
+                break;
+            }
+            else
+            {
+                // When parsing the text, it's necessary to checked if format is valid again to avoid index out of range
+                if(per_string.split("=")[0].split("\"").size() == 3)
+                {
+                    QString head = per_string.split("=")[0].split("\"")[1];
+                    QVector<QRegExp> value;
+                    QString temp;
+                    for(QString temp:per_string.split("=")[1].split(","))
+                    {
+                        // If format is valid, append regexp
+                        if(temp.split("\"").size() == 3)
+                        {
+                            value.append(QRegExp(temp.split("\"")[1], nfilterBar->caseSensitivity(), nfilterBar->patternSyntax()));
+                        }
+                        else
+                        {
+                            nsortfilterproxyModel->set_switcher(FALSE);
+                            break;
+                        }
+                    }
+                    // If format is valid, start filtering
+                    if(nsortfilterproxyModel->get_switcher())
+                    {
+                        int key = header_list.indexOf(head);
+                        // By default, when parameter "key" == -1, which means the column to be searched is -1, then the column limit will be invalid.
+                        if(key != -1)
+                        {
+                            nsortfilterproxyModel->append(key, value);
+                            nsortfilterproxyModel->setFilterRegExp(QRegExp());
+                        }
+                        // Can't find specific head in header_list
+                        else
+                        {
+                            global_filter();
+                            break;
+                        }
+                    }
+                    // format error
+                    else
+                    {
+                        global_filter();
+                        break;
+                    }
+                }
+                // format error
+                else
+                {
+                    global_filter();
+                    break;
+                }
+            }
+        }
+    }
+    // Not using complex filter function
+    else
+    {
+        global_filter();
+    }
+
+//    match
+//    QModelIndexList nidx = nsortfilterproxyModel->match(
+//                nsortfilterproxyModel->index(0,2)
+//                , Qt::DisplayRole
+//                , "5", -1, Qt::MatchContains);
+
+}
+
+// Filter key words globally
+void Window::global_filter()
+{
+    nsortfilterproxyModel->set_switcher(FALSE);
+    QRegExp regExp(nfilterBar->get_filter_editor_text(),
+                   nfilterBar->caseSensitivity(),
+                   nfilterBar->patternSyntax());
+    nsortfilterproxyModel->setFilterRegExp(regExp);
+}
+
+void Window::prev()
+{
+    // to be completed
+    return;
+}
+
+void Window::next()
+{
+    // to be completed
+    return;
+}
+
+


### PR DESCRIPTION
- 更改了一些函数和变量的命名及组织方式（就是把main中增加组件的函数写到了window里面去 哈哈哈）。

- ntableview过滤功能：
主要相关文件为nfilterbar.h, nfilterbar.cpp, nsortfilterproxymodel.h, nsortfilterproxymodel.cpp, window.h, window.cpp。
增加了过滤栏，用CTRL+I实现快捷显示和隐藏。
扩充对Header行的右键菜单功能。
过滤功能的完成基于QSortFilterProxyModel，主要重写NSortFilterProxyModel::filterAcceptsRow函数的逻辑判断条件，来实现复杂的过滤需求。
目前过滤函数Window::filter写在window.cpp文件中，由switcher控制开关，只有完美匹配正则表达式才能进入复杂过滤功能中，正确输入示例为: "column_name1" = {"string1", "string2"} | "column_name2" = {"string3",} ，该语句的语义解释为寻找---列名column_name1对应的行包含string1或string2 且 列名为column_name2对应的行包含string3---的所有行，可以通过编辑栏前的菜单按钮来选择以正则表达式搜索，或是fixed string搜索。
